### PR TITLE
Fixed the logic to get the field name

### DIFF
--- a/src/Serializer/FormNormalizer.php
+++ b/src/Serializer/FormNormalizer.php
@@ -120,13 +120,7 @@ class FormNormalizer implements NormalizerInterface, CacheableSupportsMethodInte
                 return;
             }
 
-            $key = '';
-            $parent = $form;
-            do {
-                $key = ((string) $parent->getPropertyPath()) . $key;
-                $parent = $parent->getParent();
-            } while ($parent);
-
+            $key = $this->getKeyForField($form);
             $data['formData'][$key] = $form->getData();
 
             if ($form->isRequired()) {
@@ -141,6 +135,23 @@ class FormNormalizer implements NormalizerInterface, CacheableSupportsMethodInte
                 $data['verifiableFields'][] = $key;
             }
         }
+    }
+
+    private function getKeyForField(FormInterface $field): string
+    {
+        $parent = null;
+        if ($field->getParent()) {
+            $parent = $this->getKeyForField($field->getParent());
+        }
+
+        $name = (string) $field->getName();
+        if ($parent) {
+            $key = sprintf('%s[%s]', $parent, $name);
+        } else {
+            $key = $name;
+        }
+
+        return $key;
     }
 
     /**


### PR DESCRIPTION
Hi @arnaud-ritti 

I've reviewed the issue in #9 described by @Digi92 and added a fix for the logic.

I tried to replicate Symfony's method to generate the field name (https://github.com/symfony/form/blob/6.4/Extension/Core/Type/BaseType.php#L54).

I don't understand why the tests didn't fail. I can use both logics, and the tests work fine. Maybe Symfony behaves differently if you use an Entity as data for the form.

Kind regards,
zepich